### PR TITLE
Fix bug in lrange method

### DIFF
--- a/lib/async/redis/methods/lists.rb
+++ b/lib/async/redis/methods/lists.rb
@@ -73,7 +73,7 @@ module Async
 				end
 
 				def lrange(key, start, stop)
-					return call('LRANGE', key. start, stop)
+					return call('LRANGE', key, start, stop)
 				end
 
 				def lrem(key, count, value)

--- a/spec/async/redis/dsl/lists_spec.rb
+++ b/spec/async/redis/dsl/lists_spec.rb
@@ -56,8 +56,15 @@ RSpec.describe Async::Redis::Methods::Lists, timeout: 5 do
 
 	end
 
-	it "can get a list slice and trim lists" do
+	it "can get a list slice" do
+		client.rpush(list_a, test_list)
 
+		slice_size = list_a.size/2
+
+		expect(client.lrange(list_a, 0, slice_size - 1))
+			.to match_array test_list.take(slice_size).map(&:to_s)
+
+		client.close
 	end
 
 	it "can trim lists" do


### PR DESCRIPTION
`lrange` crashes because there's a `.` instead of a `,`.
I took the opportunity to add a test for `lrange`.