### PR TITLE
Add failing test with a large response from Redis

### DIFF
--- a/spec/async/redis/client_spec.rb
+++ b/spec/async/redis/client_spec.rb
@@ -79,4 +79,16 @@ RSpec.describe Async::Redis::Client, timeout: 5 do
 		
 		client.close
 	end
+
+	it "retrieves large responses from redis" do
+		num_elems = 5000
+		client.call("DEL", list_key)
+	  num_elems.times { |i| client.call("RPUSH", list_key, i) }
+
+		response = client.call("LRANGE", list_key, 0, num_elems - 1)
+
+		expect(response).to eq (0...num_elems).map(&:to_s)
+
+		client.close
+	end
 end


### PR DESCRIPTION
I added a test that shows that LRANGE crashes when it receives a large response from Redis as discussed in #4 