### PR TITLE
Call .flush once per command

### DIFF
--- a/lib/async/redis/protocol/resp.rb
+++ b/lib/async/redis/protocol/resp.rb
@@ -121,6 +121,26 @@ module Async
 				end
 				
 				alias read_response read_object
+
+				private
+
+				# Override Async::IO::Protocol::Line#write_line
+				# The original method performs a flush. This one does not and moves the
+				# responsibility of flushing to the caller of the method.
+				# In the case of Redis, we do not want to perform a flush in every line,
+				# because each Redis command contains several lines. Flushing once per
+				# command is more efficient because it avoids unnecessary writes to the
+				# socket.
+				def write_lines(*args)
+					if args.empty?
+						@stream.write(@eol)
+					else
+						args.each do |arg|
+							@stream.write(arg)
+							@stream.write(@eol)
+						end
+					end
+				end
 			end
 		end
 	end


### PR DESCRIPTION
This PR overrides `Async::IO::Protocol::Line#write_line` in `Async::Redis::Protocol::RESP`.

The original method performs a flush. This one does not and moves the responsibility of flushing to the caller of the method.

In the case of Redis, we do not want to perform a flush in every line, because each Redis command contains several lines. Flushing once per command is more efficient because it avoids unnecessary writes to the socket.

In a project that I'm working on, I noticed that, when using this library, a large % of the CPU time was spent on the `write_lines` method. Then I discovered that each call to that method performs a "flush" (https://github.com/socketry/async-io/blob/6b26891275d0b1b17f3edf5ce286c79c15066114/lib/async/io/protocol/line.rb#L45) which results in an IO.write (https://github.com/socketry/async-io/blob/6b26891275d0b1b17f3edf5ce286c79c15066114/lib/async/io/stream.rb#L141). After applying this patch, the % of CPU time spent on `write_lines` went down significantly.
