### PR TITLE
Add redis-rb with hiredis to the perf benchmarks

### DIFF
--- a/async-redis.gemspec
+++ b/async-redis.gemspec
@@ -28,4 +28,9 @@ Gem::Specification.new do |spec|
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "rspec", "~> 3.6"
 	spec.add_development_dependency "rake"
+
+	# Dependencies with C extensions
+	if defined?(RUBY_ENGINE) && RUBY_ENGINE == "ruby"
+		spec.add_development_dependency "hiredis"
+	end
 end


### PR DESCRIPTION
I saw https://github.com/socketry/async-redis/pull/9 and thought that it would be interesting to add `redis-rb` with Hiredis to the bechmarks. https://github.com/redis/redis-rb#hiredis 

Hiredis is implemented in C so the comparison is not entirely fair, but I think it's useful to know how it performs.

Results on my local machine:

```
Client Performance                                                                                                                                                              
Warming up --------------------------------------                                                                                                                               
 async-redis (pool)   780.000  i/100ms                                                                                                                                         
 async-redis (nested)   797.000  i/100ms                                                                                                                                         
 redis-rb     1.062k i/100ms                                                                                                                                         
 redis-rb (hiredis)     1.472k i/100ms                                                                                                                                         
Calculating -------------------------------------                                                                                                                               
  async-redis (pool)      8.222k (±10.0%) i/s -     41.340k in   5.077386s                                                                                                      
  async-redis (nested)      9.353k (± 9.6%) i/s -     47.023k in   5.073603s                                                                                                      
  redis-rb     10.760k (± 9.5%) i/s -     54.162k in   5.078243s                                                                                                      
  redis-rb (hiredis)     14.904k (± 5.9%) i/s -     75.072k in   5.054911s                                                                                                      
                                                                                                                                                                                
Comparison:                                                                                                                                                                     
  redis-rb (hiredis):    14903.9 i/s                                                                                                                                            
  redis-rb:    10759.8 i/s - 1.39x  slower                                                                                                                            
  async-redis (nested):     9353.0 i/s - 1.59x  slower                                                                                                                            
  async-redis (pool):     8221.5 i/s - 1.81x  slower   
```

I think that in the future we could add more redis commands. We could select the commands to test based on what the `redis-benchmark` tool tests: https://redis.io/topics/benchmarks