### PR TITLE
Delete unnecessary .close() call in disconnect spec

### DIFF
--- a/spec/async/redis/disconnect_spec.rb
+++ b/spec/async/redis/disconnect_spec.rb
@@ -11,7 +11,6 @@ RSpec.describe Async::Redis::Client, timeout: 5 do
 				stream = Async::IO::Stream.new(connection)
 				stream.read(8)
 				stream.close
-				connection.close
 			end
 		end
 


### PR DESCRIPTION
`stream.close` already closes the underlying connection.