### PR TITLE
Add support for pipelines

### DIFF
--- a/lib/async/redis/client.rb
+++ b/lib/async/redis/client.rb
@@ -22,6 +22,7 @@ require_relative 'protocol/resp'
 require_relative 'pool'
 require_relative 'context/multi'
 require_relative 'context/subscribe'
+require_relative 'context/pipeline'
 
 require_relative 'methods/strings'
 require_relative 'methods/keys'
@@ -113,7 +114,20 @@ module Async
 					context.close
 				end
 			end
-			
+
+			def pipelined(&block)
+				context = Context::Pipeline.new(@pool)
+
+				return context unless block_given?
+
+				begin
+					yield context
+					context.run
+				ensure
+					context.close
+				end
+			end
+
 			def call(*arguments)
 				@pool.acquire do |connection|
 					connection.write_request(arguments)

--- a/lib/async/redis/context/pipeline.rb
+++ b/lib/async/redis/context/pipeline.rb
@@ -1,0 +1,39 @@
+module Async
+	module Redis
+		module Context
+
+			# This class accumulates commands and sends several of them in a single
+			# request, instead of sending them one by one.
+			class Pipeline < Nested
+
+				def initialize(connection_pool)
+					super(connection_pool)
+
+					# Each command is an array where the first element is the name of the
+					# command ('SET', 'GET', etc.) and the rest of elements are the
+					# parameters for that command.
+					# Ex: ['SET', 'some_key', 42].
+					@commands = []
+				end
+
+				# This method just accumulates the commands and their params.
+				def call(*args)
+					@commands << args
+				end
+
+				# Send to redis all the accumulated commands.
+				# Returns an array with the result for each command in the same order
+				# that they were added with .call().
+				def run
+					@connection.write_pipeline(@commands)
+
+					result = @commands.size.times.map { @connection.read_response }
+
+					@commands = []
+
+					result
+				end
+			end
+		end
+	end
+end

--- a/lib/async/redis/protocol/resp.rb
+++ b/lib/async/redis/protocol/resp.rb
@@ -42,18 +42,18 @@ module Async
 				end
 				
 				# The redis server doesn't want actual objects (e.g. integers) but only bulk strings. So, we inline it for performance.
-				def write_request(arguments)
+				def write_request(arguments, flush: true)
 					write_lines("*#{arguments.count}")
-					
+
 					arguments.each do |argument|
 						string = argument.to_s
-						
+
 						write_lines("$#{string.bytesize}", string)
 					end
-					
-					@stream.flush
+
+					@stream.flush if flush
 				end
-				
+
 				def write_object(object)
 					case object
 					when String
@@ -117,6 +117,14 @@ module Async
 				end
 				
 				alias read_response read_object
+
+				def write_pipeline(commands)
+					commands.each do |command|
+						write_request(command, flush: false)
+					end
+
+					@stream.flush
+				end
 
 				private
 

--- a/spec/async/redis/client_spec.rb
+++ b/spec/async/redis/client_spec.rb
@@ -93,4 +93,18 @@ RSpec.describe Async::Redis::Client, timeout: 5 do
 		
 		client.close
 	end
+
+	it "can use pipelining" do
+		client.set 'async_redis_test_key_1', 'a'
+		client.set 'async_redis_test_key_2', 'b'
+
+	  res = client.pipelined do |context|
+	    context.get 'async_redis_test_key_1'
+			context.get 'async_redis_test_key_2'
+		end
+
+		expect(res).to eq ['a', 'b']
+
+		client.close
+	end
 end

--- a/spec/async/redis/context/pipeline_spec.rb
+++ b/spec/async/redis/context/pipeline_spec.rb
@@ -1,0 +1,62 @@
+require 'async/redis/client'
+require 'async/redis/context/pipeline'
+
+RSpec.describe Async::Redis::Context::Pipeline, timeout: 5 do
+	include_context Async::RSpec::Reactor
+
+	let(:endpoint) {Async::Redis.local_endpoint}
+	let(:client) {Async::Redis::Client.new(endpoint)}
+	let(:pool) {client.instance_variable_get(:@pool)}
+	let(:pipeline) {Async::Redis::Context::Pipeline.new(pool)}
+
+	let(:example_key_vals) do
+	  { pipeline_key_1: '123', pipeline_key_2: '456' }
+	end
+
+	describe '.call' do
+	  it 'accumulates commands without running them' do
+			example_key_vals.each do |k, v|
+				pipeline.call('SET', k, v)
+			end
+
+			pipeline.close
+
+			example_key_vals.keys do |k|
+				expect(client.get k).to be nil
+			end
+
+			client.close
+	  end
+	end
+
+	describe '.run' do
+	  it 'runs the accumulated commands' do
+			example_key_vals.each do |k, v|
+				pipeline.call('SET', k, v)
+			end
+
+			pipeline.run
+			pipeline.close
+
+			example_key_vals.keys do |k, v|
+				expect(client.get k).to eq v
+			end
+
+			client.close
+		end
+
+		it 'empties the accumulated commands so they are not duplicated on the next run' do
+		  test_key = 'pipeline_key_incr'
+
+			2.times { pipeline.call('INCR', test_key) }
+
+			pipeline.run
+			pipeline.run # will not increase
+			pipeline.close
+
+			expect(client.get test_key).to eq '2'
+
+			client.close
+		end
+	end
+end


### PR DESCRIPTION
This PR adds support for pipelines: https://redis.io/topics/pipelining

Usage:
```ruby
require 'async/redis'

client = Async::Redis::Client.new

Async.run do
  result = client.pipelined { |context| context.get 'a'; context.get 'b' }
  # result now contains an array of two positions with the values for 'a' and 'b'.
end
```

A straightforward way to check that the commands are send together instead of 1 by 1:
1 - Run `nc -l 6379`
2 - Execute the lines in the example usage
3 - Check that nc sees the 2 GETs together. The client did not wait for the value of 'a' before asking for the value of 'b'.