### PR TITLE
Retire disconnected resources from the pool

### DIFF
--- a/lib/async/redis/pool.rb
+++ b/lib/async/redis/pool.rb
@@ -113,7 +113,11 @@ module Async
 			
 			def available_resource
 				while resource = @resources.pop
-					return resource if resource.connected?
+					if resource.connected?
+						return resource
+					else
+						retire(resource)
+					end
 				end
 				
 				if !@limit or @active < @limit


### PR DESCRIPTION
Fixes #23 

@ioquatix I think the fix that you applied in https://github.com/socketry/async-redis/commit/7496404e8410b60cefbe72fab0c5c5ca0b3ba6b8 is incomplete.

If we don't retire the connections, .close() is never called and the connections will be there in `CLOSE_WAIT` until the program exits.