### PR TITLE
Bump protocol-redis version number

### DIFF
--- a/async-redis.gemspec
+++ b/async-redis.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 	spec.add_dependency("async-io", "~> 1.10")
 	spec.add_dependency("async-pool", "~> 0.2")
 	
-	spec.add_dependency("protocol-redis", "~> 0.3.0")
+	spec.add_dependency("protocol-redis", "~> 0.3.1")
 	
 	spec.add_development_dependency "async-rspec", "~> 1.1"
 	spec.add_development_dependency "redis"


### PR DESCRIPTION
Could be cool to release the latest improvements of the protocol-redis library in v0.4.2.