### PR TITLE
Fix multi command

### DIFF
--- a/lib/async/redis/client.rb
+++ b/lib/async/redis/client.rb
@@ -90,18 +90,6 @@ module Async
 				end
 			end
 			
-			def multi(&block)
-				context = Context::Multi.new(@pool)
-				
-				return context unless block_given?
-				
-				begin
-					yield context
-				ensure
-					context.close
-				end
-			end
-			
 			def transaction(&block)
 				context = Context::Transaction.new(@pool)
 				
@@ -113,6 +101,7 @@ module Async
 					context.close
 				end
 			end
+			alias multi transaction
 
 			def pipeline(&block)
 				context = Context::Pipeline.new(@pool)


### PR DESCRIPTION
Actually, calling the Client#multi method fails as it tries to instantiate an inexistent `Async::Redis::Context::Multi` class.

```ruby
 7.68s    error: Async::Task [oid=0x1c48] [pid=44325] [2020-02-13 22:48:03 +0100]
               |   NameError: uninitialized constant Async::Redis::Context::Multi
               |   → ./ruby-2.7.0@quiq/gems/async-redis-0.4.3/lib/async/redis/client.rb:94 in `multi'
```
It seems that this class is no more than the same thing as the `Async::Redis::Context::Transaction` class, that's what i aliased the `multi` method to the `transaction` one.

I'd like to know if it's the best approach.

Regards