### PR TITLE
Add support for Redis Sentinels

### DIFF
--- a/lib/async/redis.rb
+++ b/lib/async/redis.rb
@@ -22,3 +22,4 @@
 
 require_relative 'redis/version'
 require_relative 'redis/client'
+require_relative 'redis/sentinels'

--- a/lib/async/redis/sentinels.rb
+++ b/lib/async/redis/sentinels.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Async
+	module Redis
+		class SentinelsClient < Client
+			def initialize(master_name, sentinels, role = :master, protocol = Protocol::RESP2, **options)
+				@master_name = master_name
+				@sentinel_endpoints = sentinels.map do |sentinel|
+					Async::IO::Endpoint.tcp(sentinel[:host], sentinel[:port])
+				end
+				@role = role
+
+				@protocol = protocol
+				@pool = connect(**options)
+			end
+
+			private
+
+			# Override the parent method. The only difference is that this one needs
+			# to resolve the master/slave address.
+			def connect(**options)
+				Async::Pool::Controller.wrap(**options) do
+					endpoint = resolve_address
+					peer = endpoint.connect
+					stream = IO::Stream.new(peer)
+
+					@protocol.client(stream)
+				end
+			end
+
+			def resolve_address
+				address = case @role
+									when :master then resolve_master
+									when :slave then resolve_slave
+									else raise ArgumentError, "Unknown instance role #{@role}"
+									end
+
+				address or raise RuntimeError, "Unable to fetch #{@role} via Sentinel."
+			end
+
+			def resolve_master
+				@sentinel_endpoints.each do |sentinel_endpoint|
+					client = Client.new(sentinel_endpoint)
+					address = client.call('sentinel', 'get-master-addr-by-name', @master_name)
+					return Async::IO::Endpoint.tcp(address[0], address[1]) if address
+				end
+
+				nil
+			end
+
+			def resolve_slave
+				@sentinel_endpoints.each do |sentinel_endpoint|
+					client = Client.new(sentinel_endpoint)
+					reply = client.call('sentinel', 'slaves', @master_name)
+
+					if slave = select_slave(reply)
+						return Async::IO::Endpoint.tcp(slave['ip'], slave['port'])
+					end
+				end
+
+				nil
+			end
+
+			def select_slave(slaves_cmd_reply)
+				return nil unless slaves_cmd_reply
+
+				# The reply is an array with the format: [field1, value1, field2,
+				# value2, etc.].
+				# When a slave is marked as down by the sentinel, the "flags" field
+				# (comma-separated array) contains the "s_down" value.
+				slaves_cmd_reply.map { |s| s.each_slice(2).to_h }
+						.reject { |s| s.fetch('flags').split(',').include?('s_down') }
+						.sample
+			end
+		end
+	end
+end


### PR DESCRIPTION
Closes #28 

This PR adds support for Redis Sentinels (https://redis.io/topics/sentinel-clients)

Notice that this PR is not complete. It does not have tests, does not explain how to use this in the README, and possibly does not handle all the error cases, but I'd rather work on those things after we agree on other aspects first.

In order to test this, you'll need one Redis master, a replica, and 3 sentinels. These are the commands I run to setup this on my local machine using docker, but you can adapt them to your env.

## Setup

- Run master on port 6379
```
docker run --rm -it --net=host redis --port 6379
```

- Run slave on port 6380
```
docker run --rm -it --net=host redis --port 6380
```
- Configure the slave to follow the master
```
redis-cli -p 6380 slaveof 127.0.0.1 6379
```

- Start 3 sentinels

I used this example config file from the official docs. You need to create one for each sentinel. The 3 files should be the same except for the port. I used 9000, 9001 and 9002.
```
port 9000
sentinel monitor mymaster 127.0.0.1 6379 2
sentinel down-after-milliseconds mymaster 5000
sentinel failover-timeout mymaster 60000
sentinel parallel-syncs mymaster 1
```

```
docker run --rm -it --net=host -v /tmp/sentinel1.conf:/data/sentinel.conf redis /data/sentinel.conf --port 9000 --sentinel
```

```
docker run --rm -it --net=host -v /tmp/sentinel2.conf:/data/sentinel.conf redis /data/sentinel.conf --port 9001 --sentinel
```

```
docker run --rm -it --net=host -v /tmp/sentinel3.conf:/data/sentinel.conf redis /data/sentinel.conf --port 9002 --sentinel
```

## Test

- Instantiate the client:

```ruby
sentinels = [{host: '127.0.0.1', port:9000},{host:'127.0.0.1', port:9001},{host: '127.0.0.1', port: 9002}]
client = Async::Redis::SentinelsClient.new('mymaster', sentinels)
```

- Make a request:
```ruby
client.call('get', 'some_key')
```

Notice that the request should go to the master, and not the slave. You can verify that using the `monitor` Redis command.

To test a failover you can use: `redis-cli -p 6379 debug sleep 10`. That will block the master during some seconds, and the sentinels will elect a new master.

You can use something like this to verify that the client automatically sends requests to the new master when that happens. Again, you can run monitor on both Redis instances to verify this:
```ruby
Async do
  loop do
    client.call('get', 'a')
    sleep 2
  end
end
```