### PR TITLE
Add `ensure` to Pipeline's close method

### DIFF
--- a/lib/async/redis/context/pipeline.rb
+++ b/lib/async/redis/context/pipeline.rb
@@ -97,7 +97,7 @@ module Async
 				
 				def close
 					flush
-					
+			  ensure
 					super
 				end
 			end


### PR DESCRIPTION
## Description

Ensure that the parent's close method is called in the event of a failure during the final flush. Without this, the connection is never returned to the pool, which can lead to deadlocks if a pool limit is set.

### Types of Changes

- Bug fix.

### Testing

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
