### PR TITLE
Relax async dependency version requirement

### DIFF
--- a/async-redis.gemspec
+++ b/async-redis.gemspec
@@ -13,17 +13,17 @@ Gem::Specification.new do |spec|
 	
 	spec.files = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
 	
-	spec.add_dependency "async", "~> 2.0"
-	spec.add_dependency "async-io", "~> 1.33"
-	spec.add_dependency "async-pool", "~> 0.3"
-	spec.add_dependency "protocol-redis", "~> 0.6"
+	spec.add_dependency "async", ">= 1.8", "< 3.0"
+	spec.add_dependency "async-io", "~> 1.10"
+	spec.add_dependency "async-pool", "~> 0.2"
+	spec.add_dependency "protocol-redis", "~> 0.6.0"
 	
-	spec.add_development_dependency "async-rspec", "~> 1.16"
+	spec.add_development_dependency "async-rspec", "~> 1.1"
 	spec.add_development_dependency "benchmark-ips"
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "covered"
 	spec.add_development_dependency "hiredis"
 	spec.add_development_dependency "rake"
 	spec.add_development_dependency "redis"
-	spec.add_development_dependency "rspec", "~> 3.11"
+	spec.add_development_dependency "rspec", "~> 3.6"
 end

--- a/async-redis.gemspec
+++ b/async-redis.gemspec
@@ -13,17 +13,17 @@ Gem::Specification.new do |spec|
 	
 	spec.files = Dir.glob('{lib}/**/*', File::FNM_DOTMATCH, base: __dir__)
 	
-	spec.add_dependency "async", "~> 1.8"
-	spec.add_dependency "async-io", "~> 1.10"
-	spec.add_dependency "async-pool", "~> 0.2"
-	spec.add_dependency "protocol-redis", "~> 0.6.0"
+	spec.add_dependency "async", "~> 2.0"
+	spec.add_dependency "async-io", "~> 1.33"
+	spec.add_dependency "async-pool", "~> 0.3"
+	spec.add_dependency "protocol-redis", "~> 0.6"
 	
-	spec.add_development_dependency "async-rspec", "~> 1.1"
+	spec.add_development_dependency "async-rspec", "~> 1.16"
 	spec.add_development_dependency "benchmark-ips"
 	spec.add_development_dependency "bundler"
 	spec.add_development_dependency "covered"
 	spec.add_development_dependency "hiredis"
 	spec.add_development_dependency "rake"
 	spec.add_development_dependency "redis"
-	spec.add_development_dependency "rspec", "~> 3.6"
+	spec.add_development_dependency "rspec", "~> 3.11"
 end


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
-->

As async-redis perfectly works with async 2.0 it does not make any sense to depend on the old version only

Closes #41

### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [X] I tested my changes locally.
- [ ] I tested my changes in staging.
- [ ] I tested my changes in production.
