### PR TITLE
SentinelsClient: Use the given protocol to connect to sentinels

### DIFF
--- a/lib/async/redis/sentinels.rb
+++ b/lib/async/redis/sentinels.rb
@@ -50,7 +50,7 @@ module Async
 			
 			def resolve_master
 				@sentinel_endpoints.each do |sentinel_endpoint|
-					client = Client.new(sentinel_endpoint)
+					client = Client.new(sentinel_endpoint, protocol: @protocol)
 					
 					begin
 						address = client.call('sentinel', 'get-master-addr-by-name', @master_name)
@@ -66,7 +66,7 @@ module Async
 			
 			def resolve_slave
 				@sentinel_endpoints.each do |sentinel_endpoint|
-					client = Client.new(sentinel_endpoint)
+					client = Client.new(sentinel_endpoint, protocol: @protocol)
 					
 					begin
 						reply = client.call('sentinel', 'slaves', @master_name)


### PR DESCRIPTION
I was trying to connect to some sentinels that require password authentication. For that, I created a new protocol as in the example: https://github.com/socketry/async-redis/blob/main/examples/auth/protocol.rb

```ruby
class AuthenticatedRESP2
  def initialize(password)
    @password = password
  end

  def client(stream)
    client = Async::Redis::Protocol::RESP2.client(stream)

    client.write_request(["AUTH", *@password])
    client.read_response # Ignore response.

    client
  end
end
```

When `SentinelsClient` is used, it ignores the provided protocol when it tries to resolve address for master and slaves. As a result, password protected sentinels are not supported by async-redis.

This PR includes a small change to fix that.

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
