### PR TITLE
Initial support for Redis cluster client.

### DIFF
--- a/.github/workflows/test-cluster.yaml
+++ b/.github/workflows/test-cluster.yaml
@@ -1,0 +1,41 @@
+name: Test Cluster
+
+on: [push, pull_request]
+
+permissions:
+  contents: read
+
+env:
+  CONSOLE_OUTPUT: XTerm
+
+jobs:
+  test:
+    name: ${{matrix.ruby}} on ${{matrix.os}}
+    runs-on: ${{matrix.os}}-latest
+    continue-on-error: ${{matrix.experimental}}
+    
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+        
+        ruby:
+          - "3.1"
+          - "3.2"
+          - "3.3"
+        
+        experimental: [false]
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Docker Compose
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y docker-compose
+    
+    - name: Run tests
+      timeout-minutes: 10
+      env:
+        RUBY_VERSION: ${{matrix.ruby}}
+      run: docker-compose -f cluster/docker-compose.yaml up --exit-code-from tests

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -81,7 +81,7 @@ jobs:
         path: .covered.db
   
   test-cluster:
-    name: ${{matrix.ruby}} on ${{matrix.os}} (Sentinel)
+    name: ${{matrix.ruby}} on ${{matrix.os}} (Cluster)
     runs-on: ${{matrix.os}}-latest
     
     strategy:

--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -80,10 +80,42 @@ jobs:
         name: coverage-${{matrix.os}}-${{matrix.ruby}}
         path: .covered.db
   
+  test-cluster:
+    name: ${{matrix.ruby}} on ${{matrix.os}} (Sentinel)
+    runs-on: ${{matrix.os}}-latest
+    
+    strategy:
+      matrix:
+        os:
+          - ubuntu
+        
+        ruby:
+          - "3.3"
+    
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Install Docker Compose
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y docker-compose
+    
+    - name: Run tests
+      timeout-minutes: 10
+      env:
+        RUBY_VERSION: ${{matrix.ruby}}
+      run: docker-compose -f cluster/docker-compose.yaml up --exit-code-from tests
+    
+    - uses: actions/upload-artifact@v3
+      with:
+        name: coverage-${{matrix.os}}-${{matrix.ruby}}
+        path: .covered.db
+  
   validate:
     needs: 
       - test
       - test-sentinel
+      - test-cluster
     runs-on: ubuntu-latest
     
     steps:

--- a/cluster/docker-compose.yaml
+++ b/cluster/docker-compose.yaml
@@ -1,0 +1,43 @@
+services:
+  redis-a:
+    image: redis
+    command: redis-server /etc/redis/redis.conf
+    volumes:
+      - ./node-a/cluster.conf:/etc/redis/redis.conf
+  redis-b:
+    image: redis
+    command: redis-server /etc/redis/redis.conf
+    volumes:
+      - ./node-b/cluster.conf:/etc/redis/redis.conf
+  redis-c:
+    image: redis
+    command: redis-server /etc/redis/redis.conf
+    volumes:
+      - ./node-c/cluster.conf:/etc/redis/redis.conf
+  controller:
+    image: redis
+    command: >
+      bash -c "
+      redis-cli --cluster create --cluster-yes --cluster-replicas 0 redis-a:6379 redis-b:6379 redis-c:6379;
+      while true; do
+        redis-cli -h redis-a cluster info | grep cluster_state:fail;
+        sleep 1;
+      done"
+    healthcheck:
+      test: "redis-cli -h redis-a cluster info | grep cluster_state:ok"
+      interval: 1s
+      timeout: 3s
+      retries: 30
+    depends_on:
+      - redis-a
+      - redis-b
+      - redis-c
+  tests:
+    image: ruby:${RUBY_VERSION:-latest}
+    volumes:
+      - ../:/code
+    command: bash -c "cd /code && bundle install && bundle exec sus cluster/test"
+    environment:
+      - COVERAGE=${COVERAGE}
+    depends_on:
+      - controller

--- a/cluster/node-a/cluster.conf
+++ b/cluster/node-a/cluster.conf
@@ -1,0 +1,4 @@
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes

--- a/cluster/node-b/cluster.conf
+++ b/cluster/node-b/cluster.conf
@@ -1,0 +1,4 @@
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes

--- a/cluster/node-c/cluster.conf
+++ b/cluster/node-c/cluster.conf
@@ -1,0 +1,4 @@
+cluster-enabled yes
+cluster-config-file nodes.conf
+cluster-node-timeout 5000
+appendonly yes

--- a/cluster/readme.md
+++ b/cluster/readme.md
@@ -1,0 +1,25 @@
+# Cluster Testing
+
+To test clusters, you need to set up three redis instances (shards) and bind them together into a cluster.
+
+## Running Tests
+
+``` bash
+$ cd cluster
+$ docker-compose up tests
+[+] Running 5/0
+ ✔ Container cluster-redis-b-1     Running
+ ✔ Container cluster-redis-c-1     Running
+ ✔ Container cluster-redis-a-1     Running
+ ✔ Container cluster-controller-1  Running
+ ✔ Container cluster-tests-1       Created
+Attaching to tests-1
+tests-1  | Bundle complete! 13 Gemfile dependencies, 41 gems now installed.
+tests-1  | Use `bundle info [gemname]` to see where a bundled gem is installed.
+tests-1  | 6 installed gems you directly depend on are looking for funding.
+tests-1  |   Run `bundle fund` for details
+tests-1  | 0 assertions
+tests-1  | 🏁 Finished in 4.9ms; 0.0 assertions per second.
+tests-1  | 🐇 No slow tests found! Well done!
+tests-1 exited with code 0
+```

--- a/cluster/test/async/redis/cluster_client.rb
+++ b/cluster/test/async/redis/cluster_client.rb
@@ -22,7 +22,7 @@ describe Async::Redis::ClusterClient do
 	
 	let(:cluster) {subject.new(endpoints)}
 	
-	let(:key) {"cluster-test:#{SecureRandom.hex(8)}"}
+	let(:key) {"cluster-test:fixed"}
 	let(:value) {"cluster-test-value"}
 	
 	it "can get a client for a given key" do
@@ -35,9 +35,7 @@ describe Async::Redis::ClusterClient do
 	it "can get and set values" do
 		result = nil
 		
-		pp key: key, slot: cluster.slot_for(key)
-		
-		cluster.clients_for(key) do |client, key|
+		cluster.clients_for(key) do |client|
 			client.set(key, value)
 			
 			result = client.get(key)

--- a/cluster/test/async/redis/cluster_client.rb
+++ b/cluster/test/async/redis/cluster_client.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require 'async/redis/cluster_client'
+require 'sus/fixtures/async'
+require 'securerandom'
+
+describe Async::Redis::ClusterClient do
+	include Sus::Fixtures::Async::ReactorContext
+	
+	let(:node_a) {"redis://redis-a:6379"}
+	let(:node_b) {"redis://redis-b:6379"}
+	let(:node_c) {"redis://redis-c:6379"}
+	
+	let(:endpoints) {[
+		Async::Redis::Endpoint.parse(node_a),
+		Async::Redis::Endpoint.parse(node_b),
+		Async::Redis::Endpoint.parse(node_c)
+	]}
+	
+	let(:cluster) {subject.new(endpoints)}
+	
+	let(:key) {"sentinel-test:#{SecureRandom.hex(8)}"}
+	let(:value) {"sentinel-test-value"}
+	
+	it "can get and set values" do
+		cluster.clients_for(key) do |client, key|
+			client.set(key, value)
+			expect(client.get(key)).to be == value
+		end
+	end
+end

--- a/cluster/test/async/redis/cluster_client.rb
+++ b/cluster/test/async/redis/cluster_client.rb
@@ -22,13 +22,27 @@ describe Async::Redis::ClusterClient do
 	
 	let(:cluster) {subject.new(endpoints)}
 	
-	let(:key) {"sentinel-test:#{SecureRandom.hex(8)}"}
-	let(:value) {"sentinel-test-value"}
+	let(:key) {"cluster-test:#{SecureRandom.hex(8)}"}
+	let(:value) {"cluster-test-value"}
+	
+	it "can get a client for a given key" do
+		slot = cluster.slot_for(key)
+		client = cluster.client_for(slot)
+		
+		expect(client).not.to be_nil
+	end
 	
 	it "can get and set values" do
+		result = nil
+		
+		pp key: key, slot: cluster.slot_for(key)
+		
 		cluster.clients_for(key) do |client, key|
 			client.set(key, value)
-			expect(client.get(key)).to be == value
+			
+			result = client.get(key)
 		end
+		
+		expect(result).to be == value
 	end
 end

--- a/lib/async/redis.rb
+++ b/lib/async/redis.rb
@@ -6,4 +6,6 @@
 
 require_relative 'redis/version'
 require_relative 'redis/client'
+
+require_relative 'redis/cluster_client'
 require_relative 'redis/sentinel_client'

--- a/lib/async/redis/cluster_client.rb
+++ b/lib/async/redis/cluster_client.rb
@@ -86,15 +86,9 @@ module Async
 				
 				nodes = @shards.find(slot)
 				
-				pp slot: slot, nodes: nodes
-				
 				nodes = nodes.select{|node| node.role == role}
 				
-				pp filtered_nodes: nodes
-				
 				if node = nodes.sample
-					pp sampled_node: node
-					
 					return (node.client ||= Client.new(node.endpoint))
 				end
 			end
@@ -127,7 +121,6 @@ module Async
 						shards.add(range, nodes)
 					end
 					
-					pp shards: shards
 					@shards = shards
 					# @endpoints = @endpoints | endpoints
 					

--- a/lib/async/redis/cluster_client.rb
+++ b/lib/async/redis/cluster_client.rb
@@ -1,0 +1,205 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2020, by David Ortiz.
+# Copyright, 2023-2024, by Samuel Williams.
+
+require_relative 'client'
+require 'io/stream'
+
+module Async
+	module Redis
+		class ClusterClient
+			class ReloadError < StandardError
+			end
+			
+			Node = Struct.new(:id, :endpoint, :role, :health, :client)
+			
+			class RangeMap
+				def initialize
+					@ranges = []
+				end
+				
+				def add(range, value)
+					@ranges << [range, value]
+					
+					return value
+				end
+				
+				def find(key)
+					@ranges.each do |range, value|
+						return value if range.include?(key)
+					end
+					
+					if block_given?
+						return yield
+					end
+					
+					return nil
+				end
+				
+				def each
+					@ranges.each do |range, value|
+						yield value
+					end
+				end
+				
+				def clear
+					@ranges.clear
+				end
+			end
+			
+			# Create a new instance of the cluster client.
+			#
+			# @property endpoints [Array(Endpoint)] The list of cluster endpoints.
+			def initialize(endpoints, **options)
+				@endpoints = endpoints
+				@shards = nil
+			end
+			
+			def clients_for(*keys, attempts: 3)
+				slots = slots_for(keys)
+				
+				slots.map do |slot, keys|
+					yield client_for(slot), keys
+				end
+			rescue ServerError => error
+				if error.message =~ /MOVED|ASK/
+					reload_cluster!
+					
+					attempts -= 1
+					
+					retry if attempts > 0
+				else
+					raise
+				end
+			end
+			
+			def client_for(slot, role = :master)
+				unless @nodes
+					reload_cluster!
+				end
+				
+				nodes = @shards.find(slot)
+				
+				nodes = nodes.select{|node| node.role == role}
+				
+				if node = nodes.sample
+					node.client ||= Client.new(node.endpoint)
+				end
+			end
+			
+			protected
+			
+			def reload_cluster!(endpoints = @endpoints)
+				@endpoints.each do |endpoint|
+					client = Client.new(endpoint)
+					
+					shards = RangeMap.new
+					endpoints = []
+					
+					client.call('CLUSTER', 'SHARDS').each do |shard|
+						shard = shard.each_slice(2).to_h
+						
+						slots = shard['slots']
+						range = Range.new(*slots, exclude_end: false)
+						
+						nodes = shard['nodes'].map do |node|
+							node = node.each_slice(2).to_h
+							endpoint = Endpoint.remote(node['ip'], node['port'])
+							
+							# Collect all endpoints:
+							endpoints << endpoint
+							
+							Node.new(node['id'], endpoint, node['role'].to_sym, node['health'].to_sym)
+						end
+						
+						shards.add(range, nodes)
+					end
+					
+					@shards = shards
+					# @endpoints = @endpoints | endpoints
+					
+					return true
+				rescue Errno::ECONNREFUSED
+					next
+				end
+				
+				raise ReloadError, "Failed to reload cluster configuration."
+			end
+			
+			XMODEM_CRC16_LOOKUP = [
+				0x0000, 0x1021, 0x2042, 0x3063, 0x4084, 0x50a5, 0x60c6, 0x70e7,
+				0x8108, 0x9129, 0xa14a, 0xb16b, 0xc18c, 0xd1ad, 0xe1ce, 0xf1ef,
+				0x1231, 0x0210, 0x3273, 0x2252, 0x52b5, 0x4294, 0x72f7, 0x62d6,
+				0x9339, 0x8318, 0xb37b, 0xa35a, 0xd3bd, 0xc39c, 0xf3ff, 0xe3de,
+				0x2462, 0x3443, 0x0420, 0x1401, 0x64e6, 0x74c7, 0x44a4, 0x5485,
+				0xa56a, 0xb54b, 0x8528, 0x9509, 0xe5ee, 0xf5cf, 0xc5ac, 0xd58d,
+				0x3653, 0x2672, 0x1611, 0x0630, 0x76d7, 0x66f6, 0x5695, 0x46b4,
+				0xb75b, 0xa77a, 0x9719, 0x8738, 0xf7df, 0xe7fe, 0xd79d, 0xc7bc,
+				0x48c4, 0x58e5, 0x6886, 0x78a7, 0x0840, 0x1861, 0x2802, 0x3823,
+				0xc9cc, 0xd9ed, 0xe98e, 0xf9af, 0x8948, 0x9969, 0xa90a, 0xb92b,
+				0x5af5, 0x4ad4, 0x7ab7, 0x6a96, 0x1a71, 0x0a50, 0x3a33, 0x2a12,
+				0xdbfd, 0xcbdc, 0xfbbf, 0xeb9e, 0x9b79, 0x8b58, 0xbb3b, 0xab1a,
+				0x6ca6, 0x7c87, 0x4ce4, 0x5cc5, 0x2c22, 0x3c03, 0x0c60, 0x1c41,
+				0xedae, 0xfd8f, 0xcdec, 0xddcd, 0xad2a, 0xbd0b, 0x8d68, 0x9d49,
+				0x7e97, 0x6eb6, 0x5ed5, 0x4ef4, 0x3e13, 0x2e32, 0x1e51, 0x0e70,
+				0xff9f, 0xefbe, 0xdfdd, 0xcffc, 0xbf1b, 0xaf3a, 0x9f59, 0x8f78,
+				0x9188, 0x81a9, 0xb1ca, 0xa1eb, 0xd10c, 0xc12d, 0xf14e, 0xe16f,
+				0x1080, 0x00a1, 0x30c2, 0x20e3, 0x5004, 0x4025, 0x7046, 0x6067,
+				0x83b9, 0x9398, 0xa3fb, 0xb3da, 0xc33d, 0xd31c, 0xe37f, 0xf35e,
+				0x02b1, 0x1290, 0x22f3, 0x32d2, 0x4235, 0x5214, 0x6277, 0x7256,
+				0xb5ea, 0xa5cb, 0x95a8, 0x8589, 0xf56e, 0xe54f, 0xd52c, 0xc50d,
+				0x34e2, 0x24c3, 0x14a0, 0x0481, 0x7466, 0x6447, 0x5424, 0x4405,
+				0xa7db, 0xb7fa, 0x8799, 0x97b8, 0xe75f, 0xf77e, 0xc71d, 0xd73c,
+				0x26d3, 0x36f2, 0x0691, 0x16b0, 0x6657, 0x7676, 0x4615, 0x5634,
+				0xd94c, 0xc96d, 0xf90e, 0xe92f, 0x99c8, 0x89e9, 0xb98a, 0xa9ab,
+				0x5844, 0x4865, 0x7806, 0x6827, 0x18c0, 0x08e1, 0x3882, 0x28a3,
+				0xcb7d, 0xdb5c, 0xeb3f, 0xfb1e, 0x8bf9, 0x9bd8, 0xabbb, 0xbb9a,
+				0x4a75, 0x5a54, 0x6a37, 0x7a16, 0x0af1, 0x1ad0, 0x2ab3, 0x3a92,
+				0xfd2e, 0xed0f, 0xdd6c, 0xcd4d, 0xbdaa, 0xad8b, 0x9de8, 0x8dc9,
+				0x7c26, 0x6c07, 0x5c64, 0x4c45, 0x3ca2, 0x2c83, 0x1ce0, 0x0cc1,
+				0xef1f, 0xff3e, 0xcf5d, 0xdf7c, 0xaf9b, 0xbfba, 0x8fd9, 0x9ff8,
+				0x6e17, 0x7e36, 0x4e55, 0x5e74, 0x2e93, 0x3eb2, 0x0ed1, 0x1ef0
+			].freeze
+			
+			# This is the CRC16 algorithm used by Redis Cluster to hash keys.
+			# Copied from https://github.com/antirez/redis-rb-cluster/blob/master/crc16.rb
+			def crc16(bytes)
+				crc = 0
+				
+				bytes.each_byte do |b|
+					crc = ((crc << 8) & 0xffff) ^ XMODEM_CRC16_LOOKUP[((crc >> 8) ^ b) & 0xff]
+				end
+				
+				return crc
+			end
+			
+			HASH_SLOTS = 16_384
+			
+			# Return Redis::Client for a given key.
+			# Modified from https://github.com/antirez/redis-rb-cluster/blob/master/cluster.rb#L104-L117
+			def slot_for(key)
+				key = key.to_s
+				
+				if s = key.index('{')
+					if e = key.index('}', s + 1) and e != s + 1
+						key = key[s + 1..e - 1]
+					end
+				end
+				
+				return crc16(key) % HASH_SLOTS
+			end
+			
+			def slots_for(keys)
+				slots = Hash.new{|hash, key| hash[key] = []}
+				
+				keys.each do |key|
+					slots[slot_for(key)] << key
+				end
+				
+				return slots
+			end
+		end
+	end
+end

--- a/sentinel/readme.md
+++ b/sentinel/readme.md
@@ -7,14 +7,21 @@ To test sentinels, you need to set up master, slave and sentinel instances.
 ``` bash
 $ cd sentinel
 $ docker-compose up tests
-[+] Running 3/3
- ✔ Container sentinel-redis-master-1    Running                              0.0s 
- ✔ Container sentinel-redis-slave-1     Running                              0.0s 
- ✔ Container sentinel-redis-sentinel-1  Started                              0.2s 
+[+] Running 4/0
+ ✔ Container sentinel-redis-master-1    Created
+ ✔ Container sentinel-redis-slave-1     Created
+ ✔ Container sentinel-redis-sentinel-1  Created
+ ✔ Container sentinel-tests-1           Created
+Attaching to tests-1
+tests-1  | Bundle complete! 13 Gemfile dependencies, 41 gems now installed.
+tests-1  | Use `bundle info [gemname]` to see where a bundled gem is installed.
+tests-1  | 6 installed gems you directly depend on are looking for funding.
+tests-1  |   Run `bundle fund` for details
+tests-1  | 3 passed out of 3 total (3 assertions)
+tests-1  | 🏁 Finished in 4.1s; 0.74 assertions per second.
+tests-1  | 🐢 Slow tests:
+tests-1  | 	4.1s: describe Async::Redis::SentinelClient it should resolve slave address sentinel/test/async/redis/sentinel_client.rb:35
+tests-1 exited with code 0
+
 ```
 
-## Test
-
-``` bash
-$ ASYNC_REDIS_MASTER=redis://redis-master:6379 ASYNC_REDIS_SLAVE=redis://redis-slave:6379 ASYNC_REDIS_SENTINEL=redis://redis-sentinel:26379 bundle exec sus
-```

--- a/test/async/redis/cluster_client.rb
+++ b/test/async/redis/cluster_client.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require 'async/redis/cluster_client'
+require 'sus/fixtures/async'
+require 'securerandom'
+
+describe Async::Redis::ClusterClient do
+	let(:client) {subject.new([])}
+	
+	with "#slot_for" do
+		it "can compute the correct slot for a given key" do
+			expect(client.slot_for("helloworld")).to be == 2739
+			expect(client.slot_for("test1234")).to be == 15785
+		end
+	end
+end


### PR DESCRIPTION
This is still a very fresh implementation, but it provides the basic support for Redis cluster. Note that only Redis 7+ cluster (shards) are supported for now.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
