### PR TITLE
Correctly pass `@options` to `Async::Redis::Client` instances created by `Async::Redis::ClusterClient`.

### DIFF
--- a/lib/async/redis/cluster_client.rb
+++ b/lib/async/redis/cluster_client.rb
@@ -56,6 +56,7 @@ module Async
 			# @property endpoints [Array(Endpoint)] The list of cluster endpoints.
 			def initialize(endpoints, **options)
 				@endpoints = endpoints
+				@options = options
 				@shards = nil
 			end
 			
@@ -93,7 +94,7 @@ module Async
 				end
 				
 				if node = nodes.sample
-					return (node.client ||= Client.new(node.endpoint))
+					return (node.client ||= Client.new(node.endpoint, **@options))
 				end
 			end
 			
@@ -101,7 +102,7 @@ module Async
 			
 			def reload_cluster!(endpoints = @endpoints)
 				@endpoints.each do |endpoint|
-					client = Client.new(endpoint)
+					client = Client.new(endpoint, **@options)
 					
 					shards = RangeMap.new
 					endpoints = []


### PR DESCRIPTION
A change to allow `Async::Redis::ClusterClient` to accept an optional argument of options that are passed to `Async::Pool::Controller.wrap`. The goal of this change is to have parity with `Async::Redis::Client`.

Tests are passing but I didn't create a new test to validate the options are being passed in. I took a quick look at it but neither the `options` or `@pool` are accessible so without a few more changes (or mocking), I couldn't quite get there.