### PR TITLE
Sentinels: Accept options to connect to master

### DIFF
--- a/lib/async/redis/sentinel_client.rb
+++ b/lib/async/redis/sentinel_client.rb
@@ -26,7 +26,7 @@ module Async
 			def initialize(endpoints, master_name: DEFAULT_MASTER_NAME, master_options: nil, role: :master, **options)
 				@endpoints = endpoints
 				@master_name = master_name
-				@master_options = master_options
+				@master_options = master_options || {}
 				@role = role
 
 				@ssl = !!master_options&.key?(:ssl_context)

--- a/lib/async/redis/sentinel_client.rb
+++ b/lib/async/redis/sentinel_client.rb
@@ -21,13 +21,16 @@ module Async
 			#
 			# @property endpoints [Array(Endpoint)] The list of sentinel endpoints.
 			# @property master_name [String] The name of the master instance, defaults to 'mymaster'.
+			# @property master_options [Hash] Connection options for master.
 			# @property role [Symbol] The role of the instance that you want to connect to, either `:master` or `:slave`.
-			# @property protocol [Protocol] The protocol to use when connecting to the actual Redis server, defaults to {Protocol::RESP2}.
-			def initialize(endpoints, master_name: DEFAULT_MASTER_NAME, role: :master, protocol: Protocol::RESP2, **options)
+			def initialize(endpoints, master_name: DEFAULT_MASTER_NAME, master_options: nil, role: :master, **options)
 				@endpoints = endpoints
 				@master_name = master_name
+				@master_options = master_options
 				@role = role
-				@protocol = protocol
+
+				@ssl = !!master_options&.key?(:ssl_context)
+				@scheme = "redis#{@ssl ? 's' : ''}"
 				
 				# A cache of sentinel connections.
 				@sentinels = {}
@@ -103,8 +106,8 @@ module Async
 					rescue Errno::ECONNREFUSED
 						next
 					end
-					
-					return Endpoint.remote(address[0], address[1]) if address
+
+					return Endpoint.for(@scheme, address[0], port: address[1], **@master_options) if address
 				end
 				
 				return nil
@@ -124,7 +127,7 @@ module Async
 					next if slaves.empty?
 					
 					slave = select_slave(slaves)
-					return Endpoint.remote(slave["ip"], slave["port"])
+					return Endpoint.for(@scheme, slave["ip"], port: slave["port"], **@master_options)
 				end
 				
 				return nil
@@ -133,7 +136,6 @@ module Async
 			protected
 			
 			def assign_default_tags(tags)
-				tags[:protocol] = @protocol.to_s
 			end
 			
 			# Override the parent method. The only difference is that this one needs to resolve the master/slave address.
@@ -144,8 +146,8 @@ module Async
 					endpoint = resolve_address
 					peer = endpoint.connect
 					stream = ::IO::Stream(peer)
-					
-					@protocol.client(stream)
+
+					endpoint.protocol.client(stream)
 				end
 			end
 			

--- a/lib/async/redis/sentinel_client.rb
+++ b/lib/async/redis/sentinel_client.rb
@@ -29,7 +29,7 @@ module Async
 				@master_options = master_options || {}
 				@role = role
 
-				@ssl = !!master_options&.key?(:ssl_context)
+				@ssl = !!@master_options.key?(:ssl_context)
 				@scheme = "redis#{@ssl ? 's' : ''}"
 				
 				# A cache of sentinel connections.


### PR DESCRIPTION
I tried to use `SentinelClient` on my project and found I couldn't connect to Sentinels + TLS or ACL. The reason is there no way to provide connection options for the master, only for the sentinels. So sentinels can be protected with TLS and ACL and `async-redis` will connect to them, but after resolving master, `SentinelClient` will only connect to master if it is not protected by TLS nor ACL.

I wrote this script to test the changes:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  #gem 'async-redis'
  gem 'async-redis', git: 'https://github.com/jlledom/async-redis', branch: 'jlledom-sentinels-tls-acl'
end

def main
  Async do
    sentinels = [{ host: 'localhost', port: 56380 },
                 { host: 'localhost', port: 56381 },
                 { host: 'localhost', port: 56382 }]

    ssl_params = {
      ca_file: '/path/to/ca-root-cert.pem',
    }
    ssl_context = OpenSSL::SSL::SSLContext.new.tap do |context|
      context.set_params(ssl_params)
    end

    database = '6'
    credentials = %w[username password]
    endpoint_options = {database:, credentials:, ssl_context: }.compact

    sentinel_credentials = %w[sentinel_username sentinel_password]
    master_name = 'redis-master'
    role = :master

    endpoints = sentinels.map do |sentinel|
      scheme = ssl_context ? 'rediss' : 'redis'
      host = sentinel[:host]
      port = sentinel[:port]
      sentinel_uri = URI::Generic.build(scheme:, host:, port:)
      Async::Redis::Endpoint.new(sentinel_uri, nil, credentials: sentinel_credentials, ssl_context:)
    end
    client = Async::Redis::SentinelClient.new(endpoints, master_name:, master_options: endpoint_options, role:)

    while true
      begin
        sleep 1
        result = client.ping 'test'
        puts result
      rescue StandardError => e
        puts e.message
        retry
      end
    end
  end
end

main

```

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

I didn't add tests because those must involve much more than just writing the tests. It would require creating a new docker compose file, new certificates, config files, etc.
