### PR TITLE
Sentinels: Fix password with special characters for master

### DIFF
--- a/lib/async/redis/endpoint.rb
+++ b/lib/async/redis/endpoint.rb
@@ -63,7 +63,7 @@ module Async
 			# @parameter scheme [String, nil] The scheme to use, e.g. "redis" or "rediss". If nil, will auto-detect.
 			# @parameter hostname [String] The hostname to connect to (or bind to).
 			# @parameter options [Hash] Additional options, passed to {#initialize}.
-			def self.for(scheme, host, credentials: nil, port: nil, database: nil, **options)
+			def self.for(scheme, host, port: nil, database: nil, **options)
 				# Auto-detect scheme if not provided:
 				if default_scheme = options.delete(:scheme)
 					scheme ||= default_scheme
@@ -82,7 +82,6 @@ module Async
 				self.new(
 					uri_klass.build(
 						scheme: scheme,
-						userinfo: credentials&.join(":"),
 						host: host,
 						port: port,
 						path: path,

--- a/test/async/redis/endpoint.rb
+++ b/test/async/redis/endpoint.rb
@@ -106,8 +106,7 @@ describe Async::Redis::Endpoint do
 		
 		it "handles credentials correctly" do
 			endpoint = Async::Redis::Endpoint.for("redis", "localhost", credentials: ["user", "pass"], port: 6380)
-			expect(endpoint.url.to_s).to be == "redis://user:pass@localhost:6380"
-			expect(endpoint.url.userinfo).to be == "user:pass"
+			expect(endpoint.url.to_s).to be == "redis://localhost:6380"
 			expect(endpoint.credentials).to be == ["user", "pass"]
 		end
 		
@@ -131,11 +130,10 @@ describe Async::Redis::Endpoint do
 				port: 6380, 
 				database: 3
 			)
-			expect(endpoint.url.to_s).to be == "rediss://user:pass@[#{ipv6}]:6380/3"
+			expect(endpoint.url.to_s).to be == "rediss://[#{ipv6}]:6380/3"
 			expect(endpoint.url.scheme).to be == "rediss"
 			expect(endpoint.url.host).to be == "[#{ipv6}]"
 			expect(endpoint.url.hostname).to be == ipv6
-			expect(endpoint.url.userinfo).to be == "user:pass"
 			expect(endpoint.url.port).to be == 6380
 			expect(endpoint.url.path).to be == "/3"
 			expect(endpoint).to be(:secure?)


### PR DESCRIPTION
When having some sentinels and a master behind them, and the master is protected by a password including some special characters, the client is not able to connect to master, the error is: `bad password component`

I investigated and this happens because the sentinels client calls `Enpoint#for`:

https://github.com/socketry/async-redis/blob/edc87b73ff19f6efc6c7068c39f40238f9694e07/lib/async/redis/sentinel_client.rb#L111

which ends up sending the credentials to a new `URI::Generic` instance:

https://github.com/socketry/async-redis/blob/edc87b73ff19f6efc6c7068c39f40238f9694e07/lib/async/redis/endpoint.rb#L85

This results in the above password error unless the password is properly URL encoded, however, in my local tests, Redis will reject the password as incorrect when receiving it encoded. To solve this I think the best solution is to not send the credentials to the URI instance at all, instead, send the credentials directly to the `Endpoint` initializer, that way there's no need to encode the password and Redis accepts it.

This works for me. Here is the script I use to make my tests locally:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  #gem 'async-redis'
  gem 'async-redis', git: 'https://github.com/jlledom/async-redis', branch: 'jlledom-sentinel-master-credentials'
end

def main
  Async do
    sentinels = [{ host: 'localhost', port: 56380 },
                 { host: 'localhost', port: 56381 },
                 { host: 'localhost', port: 56382 }]

    ssl_params = {
      ca_file: '/path/to/ca-root-cert.pem',
    }
    ssl_context = OpenSSL::SSL::SSLContext.new.tap do |context|
      context.set_params(ssl_params)
    end

    database = '6'
    credentials = %w[username secret#Passw0rd]
    master_options = {database:, credentials:, ssl_context: }.compact

    sentinel_credentials = %w[sentinel Passw0rd]
    master_name = 'redis-master'
    role = :master

    endpoints = sentinels.map do |sentinel|
      scheme = ssl_context ? 'rediss' : 'redis'
      host = sentinel[:host]
      port = sentinel[:port]
      sentinel_uri = URI::Generic.build(scheme:, host:, port:)
      Async::Redis::Endpoint.new(sentinel_uri, nil, credentials: sentinel_credentials, ssl_context:)
    end
    client = Async::Redis::SentinelClient.new(endpoints, master_name:, master_options:, role:)

    while true
      begin
        sleep 1
        result = client.ping 'test'
        puts result
      rescue StandardError => e
        puts e.message
        retry
      end
    end
  end
end

main

```

## Types of Changes

- Bug fix.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
