### PR TITLE
Endpoint: Add support for unix sockets

### DIFF
--- a/lib/async/redis/endpoint.rb
+++ b/lib/async/redis/endpoint.rb
@@ -6,6 +6,7 @@
 require "io/endpoint"
 require "io/endpoint/host_endpoint"
 require "io/endpoint/ssl_endpoint"
+require "io/endpoint/unix_endpoint"
 
 require_relative "protocol/resp2"
 require_relative "protocol/authenticated"
@@ -39,6 +40,11 @@ module Async
 			def self.remote(host, port = 6379, **options)
 				# URI::Generic.build automatically handles IPv6 addresses correctly:
 				self.new(URI::Generic.build(scheme: "redis", host: host, port: port), **options)
+			end
+
+			def self.unix(path, **options)
+				unix_endpoint = ::IO::Endpoint.unix(path, Socket::PF_UNIX)
+				self.new(URI::Generic.build(scheme: "unix", path:), unix_endpoint, **options)
 			end
 			
 			SCHEMES = {


### PR DESCRIPTION
This PR adds a helper in `Enpoint` to connect to Redis through a unix socket. The implementation supports receiving options like credentials. I tested the connection to an ACL protected server through a Unix socket and it works fine for me.

This is the script I used to test the branch locally:

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  #gem 'async-redis'
  gem 'async-redis', git: 'https://github.com/jlledom/async-redis', branch: 'jlledom-unix-endpoint'
end

def main
  Async do
    path= '/path/to/acl-redis-master.sock'
    credentials = %w[user passW0rd]
    endpoint = Async::Redis::Endpoint.unix(path, credentials:)
    client = Async::Redis::Client.new(endpoint)

    while true
      begin
        sleep 1
        result = client.ping 'test'
        puts result
      rescue StandardError => e
        puts e.message
        retry
      end
    end
  end
end

main

```

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
